### PR TITLE
Fix the dotfiles script to work from any directory

### DIFF
--- a/dotfile_manager.py
+++ b/dotfile_manager.py
@@ -142,6 +142,8 @@ if __name__ == "__main__":
     parser.add_argument("--add", help="Add a dotfile or folder to the repository")
     args = parser.parse_args()
 
+    script_path = Path(__file__).absolute()
+
     if args.sync:
         manager = DotfileManager()
         manager.update_repo()

--- a/dotfiles
+++ b/dotfiles
@@ -2,9 +2,11 @@
 
 import subprocess
 import sys
+from pathlib import Path
 
 def main():
-    subprocess.run([sys.executable, "dotfile_manager.py"] + sys.argv[1:])
+    script_path = Path(__file__).parent / "dotfile_manager.py"
+    subprocess.run([sys.executable, str(script_path)] + sys.argv[1:])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Update `dotfile_manager.py` and `dotfiles` to use absolute paths.

* **dotfile_manager.py**
  - Add `script_path` variable to store the absolute path of `dotfile_manager.py`.

* **dotfiles**
  - Import `Path` from `pathlib`.
  - Add `script_path` variable to store the absolute path of `dotfile_manager.py`.
  - Update `subprocess.run` call to use the absolute path of `dotfile_manager.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AmirMohammad2003/manager?shareId=XXXX-XXXX-XXXX-XXXX).